### PR TITLE
fix: preserve book theme colors on startup

### DIFF
--- a/book/background_color.lua
+++ b/book/background_color.lua
@@ -76,14 +76,14 @@ local bg_cached = {
 }
 
 -- Calculate the current hex value based on night mode and current settings
-local function calculateHex(is_doc_css)
+local function calculateHex(is_doc_css, doc)
     local hex = (Screen.night_mode and bg_cached.alt_night_color) and bg_cached.night_hex or bg_cached.hex
     if Screen.night_mode then
         if bg_cached.alt_night_color or not bg_cached.invert_in_night_mode then
             hex = common.invertColor(hex)
         end
         -- Invert hex again if the reflowable document is inverting it
-        if is_doc_css and common.isColorInversionActive() and not common.isGrayscale(hex) then
+        if is_doc_css and common.isColorInversionActive(doc) and not common.isGrayscale(hex) then
             hex = common.invertColor(hex)
         end
     end
@@ -272,10 +272,11 @@ end
 local original_ReaderStyleTweak_getCssText = ReaderStyleTweak.getCssText
 function ReaderStyleTweak:getCssText()
     local original_css = original_ReaderStyleTweak_getCssText(self) or ""
+    local css_hex = calculateHex(true, self.ui.document)
 
     local bg_css = [[
         body {
-            background-color: ]] .. calculateHex(true) .. [[ !important;
+            background-color: ]] .. css_hex .. [[ !important;
         }
     ]]
     return util.trim(bg_css .. original_css)

--- a/book/book.lua
+++ b/book/book.lua
@@ -19,20 +19,6 @@ local function refreshCSS()
 end
 
 local function book_menu(plugin)
-    -- Refresh CSS after initialization when color inversion is enabled (invert images)
-    -- Prevents inverted colors from being shown on opening documents
-    local original_init = plugin.init
-    function plugin:init()
-        original_init(self)
-        self.ui:registerPostReaderReadyCallback(function()
-            UIManager:nextTick(function()
-                if Screen.night_mode and common.isColorInversionActive() then
-                    refreshCSS()
-                end
-            end)
-        end)
-    end
-
     return {
         text = "Book",
         sub_item_table = {

--- a/book/book.lua
+++ b/book/book.lua
@@ -18,7 +18,7 @@ local function refreshCSS()
     end
 end
 
-local function book_menu(plugin)
+local function book_menu()
     return {
         text = "Book",
         sub_item_table = {

--- a/book/font_color.lua
+++ b/book/font_color.lua
@@ -31,14 +31,14 @@ local fg_cached = {
 }
 
 -- Calculate the current hex value based on night mode and current settings
-local function calculateHex(is_doc_css)
+local function calculateHex(is_doc_css, doc)
     local hex = (Screen.night_mode and fg_cached.alt_night_color) and fg_cached.night_hex or fg_cached.hex
     if Screen.night_mode then
         if fg_cached.alt_night_color or not fg_cached.invert_in_night_mode then
             hex = common.invertColor(hex)
         end
         -- Invert hex again if the reflowable document is inverting it
-        if is_doc_css and common.isColorInversionActive() and not common.isGrayscale(hex) then
+        if is_doc_css and common.isColorInversionActive(doc) and not common.isGrayscale(hex) then
             hex = common.invertColor(hex)
         end
     end
@@ -225,10 +225,11 @@ end
 local original_ReaderStyleTweak_getCssText = ReaderStyleTweak.getCssText
 function ReaderStyleTweak:getCssText()
     local original_css = original_ReaderStyleTweak_getCssText(self) or ""
+    local css_hex = calculateHex(true, self.ui.document)
 
     local fg_css = [[
         body {
-            color: ]] .. calculateHex(true) .. [[ !important;
+            color: ]] .. css_hex .. [[ !important;
         }
     ]]
     return util.trim(fg_css .. original_css)

--- a/lib/common.lua
+++ b/lib/common.lua
@@ -138,9 +138,15 @@ function common.contains(tbl, val)
 end
 
 -- Helper: check if reflowable documents are inverting colors according to the invert images setting
-function common.isColorInversionActive()
-    local doc = ReaderUI.instance and ReaderUI.instance.document
-    return doc and doc._nightmode_images
+function common.isColorInversionActive(doc)
+    doc = doc or (ReaderUI.instance and ReaderUI.instance.document)
+    if not doc then
+        return nil
+    end
+    if doc._nightmode_images ~= nil then
+        return doc._nightmode_images
+    end
+    return doc.configurable and doc.configurable.nightmode_images == 1
 end
 
 return common

--- a/lib/common.lua
+++ b/lib/common.lua
@@ -141,7 +141,7 @@ end
 function common.isColorInversionActive(doc)
     doc = doc or (ReaderUI.instance and ReaderUI.instance.document)
     if not doc then
-        return nil
+        return false
     end
     if doc._nightmode_images ~= nil then
         return doc._nightmode_images

--- a/main.lua
+++ b/main.lua
@@ -45,7 +45,7 @@ end
 local submenus = {
     themes_menu(),
     ui_menu(),
-    book_menu(Appearance),
+    book_menu(),
     about_menu(),
 }
 


### PR DESCRIPTION
Fix book theme colors on startup by using the active reader document when generating CSS. This ensures image-inversion state is available during initialization, avoiding incorrect inverted colors without a deferred stylesheet refresh or extra render.

Should fix #98 